### PR TITLE
fix: destructure oauth login url

### DIFF
--- a/cli/template/extras/src/routes/lucia/github-login.ts
+++ b/cli/template/extras/src/routes/lucia/github-login.ts
@@ -4,7 +4,7 @@ import { redirect } from "@sveltejs/kit";
 
 export async function GET(event: RequestEvent): Promise<Response> {
 	const oauth = use_oauth({ event, provider_id: "github" });
-	const login_url = await oauth.get_login_url();
+	const { url: login_url } = await oauth.get_login_url();
 
 	redirect(302, login_url.toString());
 }


### PR DESCRIPTION
`toString()` is called on the object instead of the URL inside the object.